### PR TITLE
Add ability to define environment variables to be set for command execution

### DIFF
--- a/src/main/kotlin/io/github/leonschreuder/kotlinexec/Exec.kt
+++ b/src/main/kotlin/io/github/leonschreuder/kotlinexec/Exec.kt
@@ -24,7 +24,8 @@ fun exec(
     stdIn: String = "",
     captureOutput: Boolean = false,
     workingDir: File = File("."),
-    redirectErrToOut: Boolean = false
+    redirectErrToOut: Boolean = false,
+    environmentVariables: Map<String, String> = mapOf()
 ): ExecResult {
     try {
         val process =
@@ -39,6 +40,8 @@ fun exec(
 
                     redirectOutput(redirection)
                     redirectError(redirection)
+
+                    environment().putAll(environmentVariables)
                 }
                 .start()
         if (stdIn != "") {


### PR DESCRIPTION

Given we're using ProcessBuilder, this is the most accurate form I could find to add environment variables to be set for the command execution